### PR TITLE
Add basic error parsing for CMake command

### DIFF
--- a/org.eclipse.cdt.cmake4cdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.cdt.cmake4cdt/META-INF/MANIFEST.MF
@@ -13,7 +13,9 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.swt,
  org.eclipse.ui.ide,
  org.eclipse.cdt.managedbuilder.ui,
- org.eclipse.jface
+ org.eclipse.jface,
+ org.eclipse.core.filesystem,
+ org.eclipse.cdt.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.cdt.cmake,

--- a/org.eclipse.cdt.cmake4cdt/OSGI-INF/l10n/bundle.properties
+++ b/org.eclipse.cdt.cmake4cdt/OSGI-INF/l10n/bundle.properties
@@ -42,3 +42,5 @@ page.name = CMake
 page.name.0 = CMake Settings
 variable.description.2 = Filesystem absolute path to the project that is build at the moment. In contrast to the eclipse build-in project_loc variable, which points to the selected project. This is useful in case of "build all", when projects get build that have not been selected before. The Value of this variable is set when Makefile is generated.
 variable.description.3 = variable holds the path to a cmake toolchain file (-DCMAKE_TOOLCHAIN_FILE) for the given architecture.
+CMakeErrorParserStderr.name = CMake Error Parser Stderr
+CMakeErrorParserStdout.name = CMake Error Parser Stdout

--- a/org.eclipse.cdt.cmake4cdt/plugin.xml
+++ b/org.eclipse.cdt.cmake4cdt/plugin.xml
@@ -404,6 +404,26 @@ The file CMakeLists.txt must exist, the Eclipse project structures (.project and
          </description>
       </wizard>
    </extension>
+   <extension
+         id="CMakeErrorParserStderr"
+         name="%CMakeErrorParseStderr.name"
+         point="org.eclipse.cdt.core.ErrorParser">
+      <errorparser
+            class="org.eclipse.cdt.cmake.CMakeErrorParserStdErr"
+            id="org.eclipse.cdt.cmake.errorParserStderr"
+            name="%CMakeErrorParseStderr.name">
+      </errorparser>
+   </extension>
+   <extension
+         id="CMakeErrorParserStdout"
+         name="%CMakeErrorParseStdout.name"
+         point="org.eclipse.cdt.core.ErrorParser">
+      <errorparser
+            class="org.eclipse.cdt.cmake.CMakeErrorParserStdOut"
+            id="org.eclipse.cdt.cmake.errorParserStdout"
+            name="%CMakeErrorParseStdout.name">
+      </errorparser>
+   </extension>
    <!--
    <extension
          point="org.eclipse.cdt.ui.CDTWizard">

--- a/org.eclipse.cdt.cmake4cdt/src/org/eclipse/cdt/cmake/Activator.java
+++ b/org.eclipse.cdt.cmake4cdt/src/org/eclipse/cdt/cmake/Activator.java
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package org.eclipse.cdt.cmake;
 
+import org.eclipse.cdt.core.model.CModelException;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
@@ -80,5 +83,43 @@ public class Activator extends AbstractUIPlugin {
 	public static String getId() {
 		// TODO Auto-generated method stub
 		return PLUGIN_ID;
+	}
+
+	/**
+	 * @noreference This method is not intended to be referenced by clients.
+	 */
+	public static void log(String message, Throwable e) {
+		Throwable nestedException;
+		if (e instanceof CModelException
+				&& (nestedException = ((CModelException) e).getException()) != null) {
+			e = nestedException;
+		}
+		log(createStatus(message, e));
+	}
+
+	/**
+	 * @noreference This method is not intended to be referenced by clients.
+	 */
+	public static void log(Throwable e) {
+		String msg= e.getMessage();
+		if (msg == null) {
+			log("Error", e); //$NON-NLS-1$
+		} else {
+			log("Error: " + msg, e); //$NON-NLS-1$
+		}
+	}
+
+	/**
+	 * @noreference This method is not intended to be referenced by clients.
+	 */
+	public static IStatus createStatus(String msg, Throwable e) {
+		return new Status(IStatus.ERROR, PLUGIN_ID, msg, e);
+	}
+
+	/**
+	 * @noreference This method is not intended to be referenced by clients.
+	 */
+	public static void log(IStatus status) {
+		getDefault().getLog().log(status);
 	}
 }

--- a/org.eclipse.cdt.cmake4cdt/src/org/eclipse/cdt/cmake/CMakeErrorParserStdErr.java
+++ b/org.eclipse.cdt.cmake4cdt/src/org/eclipse/cdt/cmake/CMakeErrorParserStdErr.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Ericsson and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
+package org.eclipse.cdt.cmake;
+
+import java.net.URI;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.cdt.core.ErrorParserManager;
+import org.eclipse.cdt.core.IErrorParser;
+import org.eclipse.cdt.core.IMarkerGenerator;
+import org.eclipse.cdt.utils.EFSExtensionManager;
+import org.eclipse.core.filesystem.URIUtil;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+
+/**
+ * Error Parser for CMake command on stderr
+ */
+public class CMakeErrorParserStdErr implements IErrorParser/*, IErrorParser4 */{
+
+	public static final String ID = "org.eclipse.cdt.cmake.errorParserStderr"; //$NON-NLS-1$
+
+	enum ErrorParserState {
+		NONE, INTRO, FIlE_PATH,
+	}
+
+	private ErrorParserState state = ErrorParserState.NONE;
+
+	/*
+	 * CMake Error: Error in cmake code at
+	 * /Users/mark/Documents/dev/eclipse-old/workspace/runtime-CDT/testCMake2/
+	 * CMakeLists.txt:32: Parse error. Function missing ending ")". End of file
+	 * reached.
+	 */
+	private static Pattern multiLineErrorIntro = Pattern.compile("CMake Error:.*");
+	private static Pattern multiLineErrorFilePath = Pattern.compile("(.*):(\\d+):");
+	/*
+	 * CMake Error at CMakeLists.txt:10 (seasdt):
+     *   Unknown CMake command "seasdt".
+	 */
+	private static Pattern multiLineErrorIntroAndFilePath = Pattern.compile("CMake Error at (.*):(\\d+)\\s*.*:");
+	private static Pattern multiLineErrorMessage = Pattern.compile(".*");;
+
+	private String currentError = "";
+	private String filePath = "";
+	private int lineNumber = 0;
+
+	@Override
+	public boolean processLine(String line, ErrorParserManager eoParser) {
+
+		switch (state) {
+		case NONE: {
+			if (multiLineErrorIntro.matcher(line).matches()) {
+				currentError = line;
+				state = ErrorParserState.INTRO;
+			} else {
+				Matcher matcher = multiLineErrorIntroAndFilePath.matcher(line);
+				if (matcher.matches()) {
+					filePath = matcher.group(1);
+					try {
+						lineNumber = Integer.parseInt(matcher.group(2));
+					} catch (NumberFormatException e) {
+						break;
+					}
+					currentError = "";
+					state = ErrorParserState.FIlE_PATH;
+				}
+			}
+			break;
+		}
+		case INTRO: {
+			state = ErrorParserState.NONE;
+			Matcher matcher = multiLineErrorFilePath.matcher(line);
+			if (matcher.matches()) {
+				filePath = matcher.group(1);
+				try {
+					lineNumber = Integer.parseInt(matcher.group(2));
+				} catch (NumberFormatException e) {
+					break;
+				}
+				currentError = "";
+				state = ErrorParserState.FIlE_PATH;
+			}
+			break;
+		}
+		case FIlE_PATH:
+			state = ErrorParserState.NONE;
+			Matcher matcher = multiLineErrorMessage.matcher(line);
+			if (matcher.matches()) {
+				currentError += line;
+				IPath path = new Path(filePath);
+				URI uri = toURI(path, eoParser);
+				path = URIUtil.toPath(uri);
+				IFile[] foundFiles = ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(URIUtil.toURI(path));
+				IFile resource = foundFiles.length > 0 && foundFiles[0] != null && foundFiles[0].exists() ? foundFiles[0] : null;
+				IPath externalPath = resource == null ? path : null;
+				eoParser.generateExternalMarker(resource, lineNumber, currentError, IMarkerGenerator.SEVERITY_ERROR_RESOURCE, "", externalPath);
+				return true;
+			}
+			break;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Converts a location {@link IPath} to an {@link URI}.
+	 * The returned URI uses the scheme and authority of the current working directory
+	 * as returned by {@link #getWorkingDirectoryURI()}
+	 *
+	 * @param path - the path to convert to URI.
+	 * @param errParserManager
+	 * @return URI
+	 */
+	private URI toURI(IPath path, ErrorParserManager errParserManager) {
+		URI uri = null;
+		URI workingDirectoryURI = errParserManager.getWorkingDirectoryURI();
+		if (path.isAbsolute()) {
+			uri = EFSExtensionManager.getDefault().createNewURIFromPath(workingDirectoryURI, path.toString());
+		} else {
+			uri = EFSExtensionManager.getDefault().append(workingDirectoryURI, path.toString());
+		}
+
+		return uri;
+	}
+
+//	TODO: Uncomment once CDT contains IErrorParser4
+//	@Override
+//	public int getStreamType() {
+//		return IErrorParser4.PARSE_STDERR;
+//	}
+}

--- a/org.eclipse.cdt.cmake4cdt/src/org/eclipse/cdt/cmake/CMakeErrorParserStdOut.java
+++ b/org.eclipse.cdt.cmake4cdt/src/org/eclipse/cdt/cmake/CMakeErrorParserStdOut.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Ericsson and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
+package org.eclipse.cdt.cmake;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.cdt.core.ErrorParserManager;
+import org.eclipse.cdt.core.IErrorParser;
+import org.eclipse.cdt.core.IMarkerGenerator;
+import org.eclipse.core.filesystem.URIUtil;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+
+/**
+ * Error Parser for CMake command on stdout
+ */
+public class CMakeErrorParserStdOut implements IErrorParser/*, IErrorParser4 */{
+
+	public static final String ID = "org.eclipse.cdt.cmake.errorParserStdout"; //$NON-NLS-1$
+
+	// See also "/path/to/CMakeFiles/CMakeOutput.log".
+	private static Pattern seeAlso = Pattern.compile("See also \"(.*)\".");
+
+	private int lineNumber = 0;
+
+	@Override
+	public boolean processLine(String line, ErrorParserManager eoParser) {
+
+		Matcher seeAlsoMatcher = seeAlso.matcher(line);
+		if (seeAlsoMatcher.matches()) {
+			String message = seeAlsoMatcher.group();
+			String path = seeAlsoMatcher.group(1);
+			IPath externalPath = new Path(path);
+			IFile[] foundFiles = ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(URIUtil.toURI(externalPath));
+			IFile resource = foundFiles.length > 0 && foundFiles[0] != null && foundFiles[0].exists() ? foundFiles[0] : null;
+			if (resource != null) {
+				externalPath = null;
+			}
+			eoParser.generateExternalMarker(resource, lineNumber, message, IMarkerGenerator.SEVERITY_INFO, "", externalPath);
+			return true;
+		}
+
+		return false;
+	}
+
+//	TODO: Uncomment once CDT contains IErrorParser4
+//	@Override
+//	public int getStreamType() {
+//		return IErrorParser4.PARSE_STDOUT;
+//	}
+}

--- a/org.eclipse.cdt.cmake4cdt/src/org/eclipse/cdt/cmake/CMakeMakefileGenerator.java
+++ b/org.eclipse.cdt.cmake4cdt/src/org/eclipse/cdt/cmake/CMakeMakefileGenerator.java
@@ -38,6 +38,7 @@ import org.eclipse.cdt.managedbuilder.core.ITool;
 import org.eclipse.cdt.managedbuilder.core.ManagedBuildManager;
 import org.eclipse.cdt.managedbuilder.core.ManagedBuilderCorePlugin;
 import org.eclipse.cdt.managedbuilder.makegen.IManagedBuilderMakefileGenerator;
+import org.eclipse.core.filesystem.URIUtil;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceDelta;
@@ -200,7 +201,8 @@ public class CMakeMakefileGenerator implements IManagedBuilderMakefileGenerator 
 			
 
 			cmakeArgs.add("-DCMAKE_EXPORT_COMPILE_COMMANDS=On");
-			cmakeArgs.add( project.getLocation().toString() );
+			IPath pathToSource = project.getLocation();
+			cmakeArgs.add(pathToSource.toOSString());
 			
 			
 			
@@ -246,7 +248,14 @@ public class CMakeMakefileGenerator implements IManagedBuilderMakefileGenerator 
 			String[] a = new String[cmakeArgs.size()];
 			buildRunnerHelper.setLaunchParameters(launcher, cmakePath, cmakeArgs.toArray(a), workingDirectoryURI, null);
 			
-			ErrorParserManager epm = new ErrorParserManager(project, workingDirectoryURI, null, null);
+			// Dummy builder only used for marker generation
+			CMakeProjectBuilderImpl markerGenerator = new CMakeProjectBuilderImpl() {
+				{
+					setCurrentProject(project);
+				}
+			};
+
+			ErrorParserManager epm = new ErrorParserManager(project, URIUtil.toURI(pathToSource), markerGenerator, new String[] { CMakeErrorParserStdErr.ID, CMakeErrorParserStdOut.ID });
 			List<IConsoleParser> consoleParsers = new ArrayList<IConsoleParser>(); 
 			buildRunnerHelper.prepareStreams(epm, consoleParsers, (org.eclipse.cdt.core.resources.IConsole) cmakeConsole, new SubProgressMonitor(monitor, 20));
 


### PR DESCRIPTION
Note that there is an issue with stderr and stdout sometimes being interleaved
which can confuse the error parser. See:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=476824

Signed-off-by: Marc-Andre Laperle malaperle@gmail.com
